### PR TITLE
Update GUI handling of long inputs

### DIFF
--- a/src/main/resources/view/PersonListCard.fxml
+++ b/src/main/resources/view/PersonListCard.fxml
@@ -25,13 +25,13 @@
             <Region fx:constant="USE_PREF_SIZE" />
           </minWidth>
         </Label>
-        <Label fx:id="name" text="\$first" styleClass="cell_big_label" maxWidth="580.0" />
+        <Label fx:id="name" text="\$first" styleClass="cell_big_label" />
         <Label fx:id="role" styleClass="role_label" text="\$role" />
       </HBox>
       <FlowPane fx:id="tags" maxWidth="300.0" />
       <Label fx:id="phone" styleClass="cell_small_label" text="\$phone" />
       <HBox spacing="0.5" alignment="CENTER_LEFT">
-        <Label fx:id="address" styleClass="cell_small_label" text="\$address" maxWidth="650.0" />
+        <Label fx:id="address" styleClass="cell_small_label" text="\$address" />
         <Label fx:id="propertyType" styleClass="property_type_label" text="\$propertyType" />
       </HBox>
       <Label fx:id="email" styleClass="cell_small_label" text="\$email" />


### PR DESCRIPTION
Only added width limit for "name" and "address" since there are important UI tags at the back.

What the output is like with a long input for the standard width. 
<img width="1423" height="246" alt="image" src="https://github.com/user-attachments/assets/08749cc3-86f6-41b2-b4c6-eb857cfab055" />

Not sure if we should put this small issue in the future enhancements